### PR TITLE
Cache instances of RecommendationManager

### DIFF
--- a/taar_api/api/views.py
+++ b/taar_api/api/views.py
@@ -1,3 +1,4 @@
+from django.core.cache import cache
 from django.conf import settings
 from django.http import JsonResponse
 
@@ -8,8 +9,14 @@ from taar.hbase_client import HBaseClient
 
 def recommendations(request, client_id):
     """Return a list of recommendations provided a telemetry client_id."""
-    hbase_client = HBaseClient(settings.HBASE_HOST)
-    profile_fetcher = ProfileFetcher(hbase_client)
-    recommendation_manager = RecommendationManager(profile_fetcher)
+    recommendation_manager = cache.get("recommendation_manager")
+    if recommendation_manager is None:
+        hbase_client = HBaseClient(settings.HBASE_HOST)
+        profile_fetcher = ProfileFetcher(hbase_client)
+        recommendation_manager = RecommendationManager(profile_fetcher)
+        # Cache the recommendation manager for 1h
+        cache.set("recommendation_manager",
+                  recommendation_manager,
+                  3600)
     recommendations = recommendation_manager.recommend(client_id, settings.TAAR_MAX_RESULTS)
     return JsonResponse({"results": recommendations})

--- a/taar_api/api/views.py
+++ b/taar_api/api/views.py
@@ -2,7 +2,7 @@ from django.core.cache import cache
 from django.conf import settings
 from django.http import JsonResponse
 
-from taar.recommenders import RecommendationManager
+from taar import recommenders
 from taar.profile_fetcher import ProfileFetcher
 from taar.hbase_client import HBaseClient
 
@@ -13,7 +13,7 @@ def recommendations(request, client_id):
     if recommendation_manager is None:
         hbase_client = HBaseClient(settings.HBASE_HOST)
         profile_fetcher = ProfileFetcher(hbase_client)
-        recommendation_manager = RecommendationManager(profile_fetcher)
+        recommendation_manager = recommenders.RecommendationManager(profile_fetcher)
         # Cache the recommendation manager for 1h
         cache.set("recommendation_manager",
                   recommendation_manager,

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,0 +1,59 @@
+import uuid
+
+import pytest
+from django.core.urlresolvers import reverse
+
+
+@pytest.fixture
+def dummy_cache(settings):
+    settings.CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+        }
+    }
+
+
+class FakeRecommendationManager(object):
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+class EmptyRecommendationManager(FakeRecommendationManager):
+
+    def recommend(self, *args, **kwargs):
+        return []
+
+
+class StaticRecommendationManager(FakeRecommendationManager):
+
+    def recommend(self, *args, **kwargs):
+        return [
+            'addon-1',
+            'addon-2',
+            'addon-N',
+        ]
+
+
+@pytest.fixture
+def empty_recommendation_manager(monkeypatch):
+    monkeypatch.setattr('taar.recommenders.RecommendationManager', EmptyRecommendationManager)
+
+
+@pytest.fixture
+def static_recommendation_manager(monkeypatch):
+    monkeypatch.setattr('taar.recommenders.RecommendationManager', StaticRecommendationManager)
+
+
+def test_empty_recommendation(dummy_cache, client, empty_recommendation_manager):
+    response = client.get(reverse('recommendations', kwargs={'client_id': str(uuid.uuid4())}))
+    assert response.status_code == 200
+    assert response['Content-Type'] == 'application/json'
+    assert response.content == b'{"results": []}'
+
+
+def test_static_recommendation(dummy_cache, client, static_recommendation_manager):
+    response = client.get(reverse('recommendations', kwargs={'client_id': str(uuid.uuid4())}))
+    assert response.status_code == 200
+    assert response['Content-Type'] == 'application/json'
+    assert response.content == b'{"results": ["addon-1", "addon-2", "addon-N"]}'


### PR DESCRIPTION
This should speed up the avg response time a lot. I set the cache expiry time so that the external  resources used by the recommenders get refreshed every hour.
The second commit only increase test coverage.