### PR TITLE
Increase the cache life to 24 hours

### DIFF
--- a/taar_api/api/views.py
+++ b/taar_api/api/views.py
@@ -6,6 +6,9 @@ from taar import recommenders
 from taar.profile_fetcher import ProfileFetcher
 from taar.hbase_client import HBaseClient
 
+# Cache the recommendation manager for 24hrs (in seconds).
+CACHE_EXPIRATION = 24 * 60 * 60
+
 
 def recommendations(request, client_id):
     """Return a list of recommendations provided a telemetry client_id."""
@@ -14,9 +17,8 @@ def recommendations(request, client_id):
         hbase_client = HBaseClient(settings.HBASE_HOST)
         profile_fetcher = ProfileFetcher(hbase_client)
         recommendation_manager = recommenders.RecommendationManager(profile_fetcher)
-        # Cache the recommendation manager for 1h
         cache.set("recommendation_manager",
                   recommendation_manager,
-                  3600)
+                  CACHE_EXPIRATION)
     recommendations = recommendation_manager.recommend(client_id, settings.TAAR_MAX_RESULTS)
     return JsonResponse({"results": recommendations})


### PR DESCRIPTION
This increases the life of the cache from 1 hour to 24 hours. Our models update on a weekly basis, but we're expiring this after 24 hours so that if a model fails to fetch the data, we live at most 24 hours without that model.