### PR TITLE
Added support for parsing out the locale information from AMO

### DIFF
--- a/taar_api/api/views.py
+++ b/taar_api/api/views.py
@@ -13,6 +13,17 @@ CACHE_EXPIRATION = 24 * 60 * 60
 def recommendations(request, client_id):
     """Return a list of recommendations provided a telemetry client_id."""
     recommendation_manager = cache.get("recommendation_manager")
+
+    extra_data = {}
+
+    locale = request.GET.get('locale', None)
+    if locale is not None:
+        extra_data['locale'] = locale
+
+    platform = request.GET.get('platform', None)
+    if platform is not None:
+        extra_data['platform'] = platform
+
     if recommendation_manager is None:
         hbase_client = HBaseClient(settings.HBASE_HOST)
         profile_fetcher = ProfileFetcher(hbase_client)
@@ -20,5 +31,7 @@ def recommendations(request, client_id):
         cache.set("recommendation_manager",
                   recommendation_manager,
                   CACHE_EXPIRATION)
-    recommendations = recommendation_manager.recommend(client_id, settings.TAAR_MAX_RESULTS)
+    recommendations = recommendation_manager.recommend(client_id,
+                                                       settings.TAAR_MAX_RESULTS,
+                                                       extra_data)
     return JsonResponse({"results": recommendations})

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -35,6 +35,24 @@ class StaticRecommendationManager(FakeRecommendationManager):
         ]
 
 
+class LocaleRecommendationManager(FakeRecommendationManager):
+
+    def recommend(self, *args, **kwargs):
+        assert len(args) >= 3
+        if args[2].get('locale', None) == "en-US":
+            return ['addon-Locale']
+        return []
+
+
+class PlatformRecommendationManager(FakeRecommendationManager):
+
+    def recommend(self, *args, **kwargs):
+        assert len(args) >= 3
+        if args[2].get('platform', None) == "WOW64":
+            return ['addon-WOW64']
+        return []
+
+
 @pytest.fixture
 def empty_recommendation_manager(monkeypatch):
     monkeypatch.setattr('taar.recommenders.RecommendationManager', EmptyRecommendationManager)
@@ -43,6 +61,16 @@ def empty_recommendation_manager(monkeypatch):
 @pytest.fixture
 def static_recommendation_manager(monkeypatch):
     monkeypatch.setattr('taar.recommenders.RecommendationManager', StaticRecommendationManager)
+
+
+@pytest.fixture
+def locale_recommendation_manager(monkeypatch):
+    monkeypatch.setattr('taar.recommenders.RecommendationManager', LocaleRecommendationManager)
+
+
+@pytest.fixture
+def platform_recommendation_manager(monkeypatch):
+    monkeypatch.setattr('taar.recommenders.RecommendationManager', PlatformRecommendationManager)
 
 
 def test_empty_recommendation(dummy_cache, client, empty_recommendation_manager):
@@ -57,3 +85,31 @@ def test_static_recommendation(dummy_cache, client, static_recommendation_manage
     assert response.status_code == 200
     assert response['Content-Type'] == 'application/json'
     assert response.content == b'{"results": ["addon-1", "addon-2", "addon-N"]}'
+
+
+def test_locale_recommendation(dummy_cache, client, locale_recommendation_manager):
+    kwargs = {'client_id': str(uuid.uuid4())}
+    response = client.get(reverse('recommendations', kwargs=kwargs), {'locale': 'en-US'})
+    assert response.status_code == 200
+    assert response['Content-Type'] == 'application/json'
+    assert response.content == b'{"results": ["addon-Locale"]}'
+
+    kwargs = {'client_id': str(uuid.uuid4())}
+    response = client.get(reverse('recommendations', kwargs=kwargs))
+    assert response.status_code == 200
+    assert response['Content-Type'] == 'application/json'
+    assert response.content == b'{"results": []}'
+
+
+def test_platform_recommendation(dummy_cache, client, platform_recommendation_manager):
+    kwargs = {'client_id': str(uuid.uuid4())}
+    response = client.get(reverse('recommendations', kwargs=kwargs), {'platform': 'WOW64'})
+    assert response.status_code == 200
+    assert response['Content-Type'] == 'application/json'
+    assert response.content == b'{"results": ["addon-WOW64"]}'
+
+    kwargs = {'client_id': str(uuid.uuid4())}
+    response = client.get(reverse('recommendations', kwargs=kwargs))
+    assert response.status_code == 200
+    assert response['Content-Type'] == 'application/json'
+    assert response.content == b'{"results": []}'


### PR DESCRIPTION
Fixes #16. The AMO server sends back locale information on the URL as CGI parameters. This just parses out the locale (and platform) and stuffs them into the extra_data dictionary that is passed into the RecommendationManager.